### PR TITLE
add support for the prescaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ Following filter configurations are available:
 * 375kHz
 * 281.25kHz
 
+To cycle through prescaler configurations, press `p`.
+The prescaler will scale down the input signal so higher frequencies
+can be measured as well (while sacrificing some precision).
+
+The following prescaler configurations are available:
+
+* Off.
+* 2
+* 4
+* 8
+
 Add-ons
 -------
 
@@ -122,8 +133,6 @@ Please see the "addons" folder for details.
 Known Issues
 ------------
 
-* The MCU has dividers which can be supported but currently are not.
-  Unless a meaningful use case is reported, I will not add support for it.
 * Currently the code drops 20 ticks out of 36,000,000 ticks (<0.6ppm error).
   However, before we use TCXO to supply clock to the MCU, fixing it (by multiplying 1.00000056)
   will not improve precision notably.


### PR DESCRIPTION
I have tested this by measuring the 125MHz RGMII TX clock (with pre-scaler value 4) on one of my SBCs.
the output from stm32-freqmeter gets pretty close to 125MHz (off by ~500Hz or so)

without a pre-scaler the output only shows between 5 and 25MHz (in other words: off by 100MHz up to 120MHz)

I also have a branch where I changed the output to consist of multiple lines - if you are interested I can create a separate pull request for that (as well as using PC13 for the LED output, which seems to be common on these cheap STM32F103C8 boards)
here's the link in case you are wondering: https://github.com/xdarklight/stm32-freqmeter/tree/wip-prescaler-multiline-output-pc13-led